### PR TITLE
removed browse prefix for osmLinks

### DIFF
--- a/js/oscviewer.js
+++ b/js/oscviewer.js
@@ -262,8 +262,7 @@ var oscviewer = (function() {
     }
 
     function formatOsmLink(val, type) {
-        var path = (type === 'user') ? '' : 'browse/';
-        return '<a href="https://www.openstreetmap.org/' + path + type + '/' + val + '" target="_blank">' + val + '</a>';
+        return '<a href="https://www.openstreetmap.org/' + type + '/' + val + '" target="_blank">' + val + '</a>';
     }
 
     function printChangesetMeta(tags) {


### PR DESCRIPTION
The prefix browse/ is not needed anymore. 
https://www.openstreetmap.org/browse/node/xxxxx
is redirected to 
https://www.openstreetmap.org/node/xxxxx