### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -274,7 +274,7 @@
         }
 
         loader.GET({
-            url: 'https://www.openstreetmap.org/api/0.6/changeset/' + id, 
+            url: 'https://api.openstreetmap.org/api/0.6/changeset/' + id, 
             zoomToExtent: true,
             postLoadCallback: handleChangeset
         });


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)